### PR TITLE
feat: add multi-repo support, issue metadata, and active label scope

### DIFF
--- a/src/commands/comment.ts
+++ b/src/commands/comment.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { api } from '../github-api.js';
-import { detectRepository } from '../git-utils.js';
+import { resolveTargetRepo } from '../config.js';
 import { spawn } from 'child_process';
 import { writeFileSync, readFileSync, unlinkSync, existsSync } from 'fs';
 import { tmpdir } from 'os';
@@ -8,12 +8,20 @@ import { join } from 'path';
 
 interface CommentOptions {
     message?: string;
+    repo?: string;
 }
 
 export async function commentCommand(issue: string, options: CommentOptions): Promise<void> {
-    const repo = await detectRepository();
+    // Resolve target repository (--repo flag > config.defaultRepo > detect from cwd)
+    const repo = await resolveTargetRepo(options.repo);
     if (!repo) {
-        console.error(chalk.red('Error:'), 'Not in a git repository with a GitHub remote');
+        if (options.repo) {
+            console.error(chalk.red('Error:'), `Invalid repo format: ${options.repo}`);
+            console.log(chalk.dim('Expected format: owner/name (e.g., bretwardjames/ghp-core)'));
+        } else {
+            console.error(chalk.red('Error:'), 'Could not determine target repository.');
+            console.log(chalk.dim('Use --repo owner/name or set defaultRepo in config'));
+        }
         process.exit(1);
     }
 
@@ -30,7 +38,17 @@ export async function commentCommand(issue: string, options: CommentOptions): Pr
     }
 
     // Get issue details to show context
-    const details = await api.getIssueDetails(repo, issueNumber);
+    let details;
+    try {
+        details = await api.getIssueDetails(repo, issueNumber);
+    } catch (error) {
+        if (error instanceof Error && error.message.includes('Repository not found')) {
+            console.error(chalk.red('Error:'), `Repository not found: ${repo.owner}/${repo.name}`);
+            console.log(chalk.dim('Check that the repository exists and you have access to it.'));
+            process.exit(1);
+        }
+        throw error;
+    }
     if (!details) {
         console.error(chalk.red('Issue not found:'), `#${issueNumber}`);
         process.exit(1);

--- a/src/commands/done.ts
+++ b/src/commands/done.ts
@@ -1,19 +1,28 @@
 import chalk from 'chalk';
 import { api } from '../github-api.js';
-import { detectRepository } from '../git-utils.js';
-import { getConfig } from '../config.js';
+import { getConfig, resolveTargetRepo } from '../config.js';
 
-export async function doneCommand(issue: string): Promise<void> {
+interface DoneOptions {
+    repo?: string;
+}
+
+export async function doneCommand(issue: string, options: DoneOptions): Promise<void> {
     const issueNumber = parseInt(issue, 10);
     if (isNaN(issueNumber)) {
         console.error(chalk.red('Error:'), 'Issue must be a number');
         process.exit(1);
     }
 
-    // Detect repository
-    const repo = await detectRepository();
+    // Resolve target repository (--repo flag > config.defaultRepo > detect from cwd)
+    const repo = await resolveTargetRepo(options.repo);
     if (!repo) {
-        console.error(chalk.red('Error:'), 'Not in a git repository with a GitHub remote');
+        if (options.repo) {
+            console.error(chalk.red('Error:'), `Invalid repo format: ${options.repo}`);
+            console.log(chalk.dim('Expected format: owner/name (e.g., bretwardjames/ghp-core)'));
+        } else {
+            console.error(chalk.red('Error:'), 'Could not determine target repository.');
+            console.log(chalk.dim('Use --repo owner/name or set defaultRepo in config'));
+        }
         process.exit(1);
     }
 
@@ -25,14 +34,24 @@ export async function doneCommand(issue: string): Promise<void> {
     }
 
     // Find the item
-    const item = await api.findItemByNumber(repo, issueNumber);
+    let item;
+    try {
+        item = await api.findItemByNumber(repo, issueNumber);
+    } catch (error) {
+        if (error instanceof Error && error.message.includes('Repository not found')) {
+            console.error(chalk.red('Error:'), `Repository not found: ${repo.owner}/${repo.name}`);
+            console.log(chalk.dim('Check that the repository exists and you have access to it.'));
+            process.exit(1);
+        }
+        throw error;
+    }
     if (!item) {
         console.error(chalk.red('Error:'), `Issue #${issueNumber} not found in any project`);
         process.exit(1);
     }
 
     const targetStatus = getConfig('doneStatus');
-    
+
     if (item.status === targetStatus) {
         console.log(chalk.yellow('Already done:'), item.title);
         return;

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -1,18 +1,28 @@
 import chalk from 'chalk';
 import { api } from '../github-api.js';
-import { detectRepository } from '../git-utils.js';
+import { resolveTargetRepo } from '../config.js';
 
-export async function moveCommand(issue: string, status: string): Promise<void> {
+interface MoveOptions {
+    repo?: string;
+}
+
+export async function moveCommand(issue: string, status: string, options: MoveOptions): Promise<void> {
     const issueNumber = parseInt(issue, 10);
     if (isNaN(issueNumber)) {
         console.error(chalk.red('Error:'), 'Issue must be a number');
         process.exit(1);
     }
 
-    // Detect repository
-    const repo = await detectRepository();
+    // Resolve target repository (--repo flag > config.defaultRepo > detect from cwd)
+    const repo = await resolveTargetRepo(options.repo);
     if (!repo) {
-        console.error(chalk.red('Error:'), 'Not in a git repository with a GitHub remote');
+        if (options.repo) {
+            console.error(chalk.red('Error:'), `Invalid repo format: ${options.repo}`);
+            console.log(chalk.dim('Expected format: owner/name (e.g., bretwardjames/ghp-core)'));
+        } else {
+            console.error(chalk.red('Error:'), 'Could not determine target repository.');
+            console.log(chalk.dim('Use --repo owner/name or set defaultRepo in config'));
+        }
         process.exit(1);
     }
 
@@ -24,7 +34,17 @@ export async function moveCommand(issue: string, status: string): Promise<void> 
     }
 
     // Find the item
-    const item = await api.findItemByNumber(repo, issueNumber);
+    let item;
+    try {
+        item = await api.findItemByNumber(repo, issueNumber);
+    } catch (error) {
+        if (error instanceof Error && error.message.includes('Repository not found')) {
+            console.error(chalk.red('Error:'), `Repository not found: ${repo.owner}/${repo.name}`);
+            console.log(chalk.dim('Check that the repository exists and you have access to it.'));
+            process.exit(1);
+        }
+        throw error;
+    }
     if (!item) {
         console.error(chalk.red('Error:'), `Issue #${issueNumber} not found in any project`);
         process.exit(1);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import { api } from '../github-api.js';
 import { detectRepository, getCurrentBranch } from '../git-utils.js';
 import { getIssueForBranch } from '../branch-linker.js';
+import { getActiveLabelScope } from '../config.js';
 
 export async function syncCommand(): Promise<void> {
     // Detect repository
@@ -20,67 +21,120 @@ export async function syncCommand(): Promise<void> {
 
     const activeLabel = api.getActiveLabelName();
     const currentBranch = await getCurrentBranch();
+    const scope = getActiveLabelScope();
 
     console.log(chalk.bold('Syncing active label:'), activeLabel);
     console.log(chalk.dim(`Current branch: ${currentBranch}`));
+    console.log(chalk.dim(`Scope: ${scope}`));
     console.log();
 
     // Find issue linked to current branch (via branch name pattern + issue body verification)
     const linkedIssue = await getIssueForBranch(repo, currentBranch || '');
 
-    // Find all issues currently with the label
-    const issuesWithLabel = await api.findIssuesWithLabel(repo, activeLabel);
-
-    // Determine what needs to change
-    const toRemove = linkedIssue
-        ? issuesWithLabel.filter(n => n !== linkedIssue.issueNumber)
-        : issuesWithLabel;
-    const needsAdd = linkedIssue && !issuesWithLabel.includes(linkedIssue.issueNumber);
-
-    // Show what will happen
-    if (toRemove.length === 0 && !needsAdd) {
-        if (linkedIssue) {
-            console.log(chalk.green('✓'), `Active label is correctly on #${linkedIssue.issueNumber}`);
-        } else {
-            console.log(chalk.yellow('No issue linked to current branch.'));
-            if (issuesWithLabel.length === 0) {
-                console.log(chalk.dim('No issues have the active label.'));
-            }
-        }
-        return;
-    }
-
-    console.log(chalk.bold('Changes needed:'));
-
-    for (const issueNum of toRemove) {
-        console.log(chalk.red('  - Remove'), activeLabel, chalk.dim(`from #${issueNum}`));
-    }
-
-    if (needsAdd && linkedIssue) {
-        console.log(chalk.green('  + Add'), activeLabel, chalk.dim(`to #${linkedIssue.issueNumber} (${linkedIssue.issueTitle})`));
-    }
-
-    console.log();
-
-    // Apply changes
     // Ensure label exists first
     await api.ensureLabel(repo, activeLabel);
 
-    for (const issueNum of toRemove) {
-        const removed = await api.removeLabelFromIssue(repo, issueNum, activeLabel);
-        if (removed) {
-            console.log(chalk.green('✓'), `Removed from #${issueNum}`);
-        } else {
-            console.log(chalk.yellow('⚠'), `Could not remove from #${issueNum}`);
+    if (scope === 'project' && linkedIssue) {
+        // Project scope: sync across all repos in the project
+        const item = await api.findItemByNumber(repo, linkedIssue.issueNumber);
+        if (!item) {
+            console.log(chalk.yellow('Warning:'), `Issue #${linkedIssue.issueNumber} not found in any project`);
+            return;
         }
-    }
 
-    if (needsAdd && linkedIssue) {
-        const added = await api.addLabelToIssue(repo, linkedIssue.issueNumber, activeLabel);
-        if (added) {
-            console.log(chalk.green('✓'), `Added to #${linkedIssue.issueNumber}`);
-        } else {
-            console.log(chalk.yellow('⚠'), `Could not add to #${linkedIssue.issueNumber}`);
+        const itemsWithLabel = await api.findProjectItemsWithLabel(item.projectId, activeLabel);
+
+        // Determine what needs to change
+        const toRemove = itemsWithLabel.filter(
+            i => !(i.number === linkedIssue.issueNumber && i.repo.fullName === repo.fullName)
+        );
+        const hasLabel = itemsWithLabel.some(
+            i => i.number === linkedIssue.issueNumber && i.repo.fullName === repo.fullName
+        );
+
+        if (toRemove.length === 0 && hasLabel) {
+            console.log(chalk.green('✓'), `Active label is correctly on #${linkedIssue.issueNumber}`);
+            return;
+        }
+
+        console.log(chalk.bold('Changes needed:'));
+        for (const i of toRemove) {
+            console.log(chalk.red('  - Remove'), activeLabel, chalk.dim(`from ${i.repo.fullName}#${i.number}`));
+        }
+        if (!hasLabel) {
+            console.log(chalk.green('  + Add'), activeLabel, chalk.dim(`to #${linkedIssue.issueNumber} (${linkedIssue.issueTitle})`));
+        }
+        console.log();
+
+        for (const i of toRemove) {
+            await api.ensureLabel(i.repo, activeLabel);
+            const removed = await api.removeLabelFromIssue(i.repo, i.number, activeLabel);
+            if (removed) {
+                console.log(chalk.green('✓'), `Removed from ${i.repo.fullName}#${i.number}`);
+            } else {
+                console.log(chalk.yellow('⚠'), `Could not remove from ${i.repo.fullName}#${i.number}`);
+            }
+        }
+
+        if (!hasLabel) {
+            const added = await api.addLabelToIssue(repo, linkedIssue.issueNumber, activeLabel);
+            if (added) {
+                console.log(chalk.green('✓'), `Added to #${linkedIssue.issueNumber}`);
+            } else {
+                console.log(chalk.yellow('⚠'), `Could not add to #${linkedIssue.issueNumber}`);
+            }
+        }
+    } else {
+        // Repo scope: only sync within current repo
+        const issuesWithLabel = await api.findIssuesWithLabel(repo, activeLabel);
+
+        // Determine what needs to change
+        const toRemove = linkedIssue
+            ? issuesWithLabel.filter(n => n !== linkedIssue.issueNumber)
+            : issuesWithLabel;
+        const needsAdd = linkedIssue && !issuesWithLabel.includes(linkedIssue.issueNumber);
+
+        // Show what will happen
+        if (toRemove.length === 0 && !needsAdd) {
+            if (linkedIssue) {
+                console.log(chalk.green('✓'), `Active label is correctly on #${linkedIssue.issueNumber}`);
+            } else {
+                console.log(chalk.yellow('No issue linked to current branch.'));
+                if (issuesWithLabel.length === 0) {
+                    console.log(chalk.dim('No issues have the active label.'));
+                }
+            }
+            return;
+        }
+
+        console.log(chalk.bold('Changes needed:'));
+
+        for (const issueNum of toRemove) {
+            console.log(chalk.red('  - Remove'), activeLabel, chalk.dim(`from #${issueNum}`));
+        }
+
+        if (needsAdd && linkedIssue) {
+            console.log(chalk.green('  + Add'), activeLabel, chalk.dim(`to #${linkedIssue.issueNumber} (${linkedIssue.issueTitle})`));
+        }
+
+        console.log();
+
+        for (const issueNum of toRemove) {
+            const removed = await api.removeLabelFromIssue(repo, issueNum, activeLabel);
+            if (removed) {
+                console.log(chalk.green('✓'), `Removed from #${issueNum}`);
+            } else {
+                console.log(chalk.yellow('⚠'), `Could not remove from #${issueNum}`);
+            }
+        }
+
+        if (needsAdd && linkedIssue) {
+            const added = await api.addLabelToIssue(repo, linkedIssue.issueNumber, activeLabel);
+            if (added) {
+                console.log(chalk.green('✓'), `Added to #${linkedIssue.issueNumber}`);
+            } else {
+                console.log(chalk.yellow('⚠'), `Could not add to #${linkedIssue.issueNumber}`);
+            }
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,18 +89,21 @@ program
     .description('Start working on an issue - creates branch and updates status')
     .option('--no-branch', 'Skip branch creation')
     .option('--no-status', 'Skip status update')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(startCommand);
 
 program
     .command('done <issue>')
     .alias('d')
     .description('Mark an issue as done')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(doneCommand);
 
 program
     .command('move <issue> <status>')
     .alias('m')
     .description('Move an issue to a different status')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(moveCommand);
 
 // Branch commands
@@ -135,6 +138,7 @@ program
     .command('assign <issue> [users...]')
     .description('Assign users to an issue (empty to assign self)')
     .option('--remove', 'Remove assignment instead of adding')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(assignCommand);
 
 // Issue creation
@@ -148,6 +152,11 @@ program
     .option('-e, --edit', 'Open $EDITOR to write issue body')
     .option('-t, --template <name>', 'Use an issue template from .github/ISSUE_TEMPLATE/')
     .option('--list-templates', 'List available issue templates')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
+    .option('-l, --labels <labels>', 'Comma-separated labels to apply (e.g., bug,priority-high)')
+    .option('-a, --assignees <users>', 'Comma-separated GitHub usernames to assign')
+    .option('--type <type>', 'Issue type (if repo supports issue types)')
+    .option('-f, --fields <fields>', 'Project fields as key=value pairs (e.g., priority=High,size=xs)')
     .action(addIssueCommand);
 
 // Field management
@@ -155,6 +164,7 @@ program
     .command('set-field <issue> <field> <value>')
     .alias('sf')
     .description('Set a field value on an issue')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(setFieldCommand);
 
 // Filtering/slicing
@@ -172,6 +182,7 @@ program
     .alias('o')
     .description('View issue details')
     .option('-b, --browser', 'Open in browser instead of terminal')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(openCommand);
 
 program
@@ -179,12 +190,14 @@ program
     .alias('c')
     .description('Add a comment to an issue')
     .option('-m, --message <text>', 'Comment text (opens editor if not provided)')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(commentCommand);
 
 program
     .command('edit <issue>')
     .alias('e')
     .description('Edit an issue description in $EDITOR')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(editCommand);
 
 // Active label sync


### PR DESCRIPTION
## Summary
This PR adds three interconnected features:

### Multi-repo Support
- Add `--repo` flag to all issue commands (`start`, `done`, `move`, `assign`, `comment`, etc.)
- Add `config.defaultRepo` setting for multi-repo projects
- Add `resolveTargetRepo()`: uses --repo flag > defaultRepo > git detection
- Fix config priority: workspace settings now override user settings (local over global)

### Issue Metadata Fields
- Add `--labels`, `--assignees`, `--type`, `--fields` flags to `add-issue` command
- Support YAML frontmatter in editor for metadata
- Parse and apply labels, assignees, issue type, and project fields on creation

### Active Label Scope
- Add `config.activeLabel.scope` setting ('repo' | 'project')
- Update start, switch, link-branch commands to use `transferActiveLabel` from core
- Update sync command to handle project-wide label sync

## Dependencies
- Requires ghp-core#13 (issue-metadata)
- Requires ghp-core#14 (active-label-scope)

## Test plan
- [ ] Test `--repo` flag on all commands
- [ ] Test `defaultRepo` config setting
- [ ] Test add-issue with metadata flags
- [ ] Test add-issue with frontmatter in editor
- [ ] Test activeLabel.scope = 'project' with start command

🤖 Generated with [Claude Code](https://claude.com/claude-code)