### PR TITLE
feat: add --repo flag for multi-repo support

### DIFF
--- a/src/commands/assign.ts
+++ b/src/commands/assign.ts
@@ -2,17 +2,18 @@ import chalk from 'chalk';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { api } from '../github-api.js';
-import { detectRepository } from '../git-utils.js';
+import { resolveTargetRepo } from '../config.js';
 
 const execAsync = promisify(exec);
 
 interface AssignOptions {
     remove?: boolean;
+    repo?: string;
 }
 
 export async function assignCommand(
-    issue: string, 
-    users: string[], 
+    issue: string,
+    users: string[],
     options: AssignOptions
 ): Promise<void> {
     const issueNumber = parseInt(issue, 10);
@@ -21,10 +22,16 @@ export async function assignCommand(
         process.exit(1);
     }
 
-    // Detect repository
-    const repo = await detectRepository();
+    // Resolve target repository (--repo flag > config.defaultRepo > detect from cwd)
+    const repo = await resolveTargetRepo(options.repo);
     if (!repo) {
-        console.error(chalk.red('Error:'), 'Not in a git repository with a GitHub remote');
+        if (options.repo) {
+            console.error(chalk.red('Error:'), `Invalid repo format: ${options.repo}`);
+            console.log(chalk.dim('Expected format: owner/name (e.g., bretwardjames/ghp-core)'));
+        } else {
+            console.error(chalk.red('Error:'), 'Could not determine target repository.');
+            console.log(chalk.dim('Use --repo owner/name or set defaultRepo in config'));
+        }
         process.exit(1);
     }
 
@@ -41,10 +48,10 @@ export async function assignCommand(
 
     try {
         if (options.remove) {
-            await execAsync(`gh issue edit ${issueNumber} --remove-assignee "${assigneeList}"`);
+            await execAsync(`gh issue edit ${issueNumber} --repo ${repo.fullName} --remove-assignee "${assigneeList}"`);
             console.log(chalk.green('✓'), `Removed ${assigneeList} from #${issueNumber}`);
         } else {
-            await execAsync(`gh issue edit ${issueNumber} --add-assignee "${assigneeList}"`);
+            await execAsync(`gh issue edit ${issueNumber} --repo ${repo.fullName} --add-assignee "${assigneeList}"`);
             console.log(chalk.green('✓'), `Assigned ${assigneeList} to #${issueNumber}`);
         }
     } catch (error: unknown) {

--- a/src/commands/comment.ts
+++ b/src/commands/comment.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { api } from '../github-api.js';
-import { detectRepository } from '../git-utils.js';
+import { resolveTargetRepo } from '../config.js';
 import { spawn } from 'child_process';
 import { writeFileSync, readFileSync, unlinkSync, existsSync } from 'fs';
 import { tmpdir } from 'os';
@@ -8,12 +8,20 @@ import { join } from 'path';
 
 interface CommentOptions {
     message?: string;
+    repo?: string;
 }
 
 export async function commentCommand(issue: string, options: CommentOptions): Promise<void> {
-    const repo = await detectRepository();
+    // Resolve target repository (--repo flag > config.defaultRepo > detect from cwd)
+    const repo = await resolveTargetRepo(options.repo);
     if (!repo) {
-        console.error(chalk.red('Error:'), 'Not in a git repository with a GitHub remote');
+        if (options.repo) {
+            console.error(chalk.red('Error:'), `Invalid repo format: ${options.repo}`);
+            console.log(chalk.dim('Expected format: owner/name (e.g., bretwardjames/ghp-core)'));
+        } else {
+            console.error(chalk.red('Error:'), 'Could not determine target repository.');
+            console.log(chalk.dim('Use --repo owner/name or set defaultRepo in config'));
+        }
         process.exit(1);
     }
 
@@ -30,7 +38,17 @@ export async function commentCommand(issue: string, options: CommentOptions): Pr
     }
 
     // Get issue details to show context
-    const details = await api.getIssueDetails(repo, issueNumber);
+    let details;
+    try {
+        details = await api.getIssueDetails(repo, issueNumber);
+    } catch (error) {
+        if (error instanceof Error && error.message.includes('Repository not found')) {
+            console.error(chalk.red('Error:'), `Repository not found: ${repo.owner}/${repo.name}`);
+            console.log(chalk.dim('Check that the repository exists and you have access to it.'));
+            process.exit(1);
+        }
+        throw error;
+    }
     if (!details) {
         console.error(chalk.red('Issue not found:'), `#${issueNumber}`);
         process.exit(1);

--- a/src/commands/done.ts
+++ b/src/commands/done.ts
@@ -1,19 +1,28 @@
 import chalk from 'chalk';
 import { api } from '../github-api.js';
-import { detectRepository } from '../git-utils.js';
-import { getConfig } from '../config.js';
+import { getConfig, resolveTargetRepo } from '../config.js';
 
-export async function doneCommand(issue: string): Promise<void> {
+interface DoneOptions {
+    repo?: string;
+}
+
+export async function doneCommand(issue: string, options: DoneOptions): Promise<void> {
     const issueNumber = parseInt(issue, 10);
     if (isNaN(issueNumber)) {
         console.error(chalk.red('Error:'), 'Issue must be a number');
         process.exit(1);
     }
 
-    // Detect repository
-    const repo = await detectRepository();
+    // Resolve target repository (--repo flag > config.defaultRepo > detect from cwd)
+    const repo = await resolveTargetRepo(options.repo);
     if (!repo) {
-        console.error(chalk.red('Error:'), 'Not in a git repository with a GitHub remote');
+        if (options.repo) {
+            console.error(chalk.red('Error:'), `Invalid repo format: ${options.repo}`);
+            console.log(chalk.dim('Expected format: owner/name (e.g., bretwardjames/ghp-core)'));
+        } else {
+            console.error(chalk.red('Error:'), 'Could not determine target repository.');
+            console.log(chalk.dim('Use --repo owner/name or set defaultRepo in config'));
+        }
         process.exit(1);
     }
 
@@ -25,14 +34,24 @@ export async function doneCommand(issue: string): Promise<void> {
     }
 
     // Find the item
-    const item = await api.findItemByNumber(repo, issueNumber);
+    let item;
+    try {
+        item = await api.findItemByNumber(repo, issueNumber);
+    } catch (error) {
+        if (error instanceof Error && error.message.includes('Repository not found')) {
+            console.error(chalk.red('Error:'), `Repository not found: ${repo.owner}/${repo.name}`);
+            console.log(chalk.dim('Check that the repository exists and you have access to it.'));
+            process.exit(1);
+        }
+        throw error;
+    }
     if (!item) {
         console.error(chalk.red('Error:'), `Issue #${issueNumber} not found in any project`);
         process.exit(1);
     }
 
     const targetStatus = getConfig('doneStatus');
-    
+
     if (item.status === targetStatus) {
         console.log(chalk.yellow('Already done:'), item.title);
         return;

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -1,18 +1,28 @@
 import chalk from 'chalk';
 import { api } from '../github-api.js';
-import { detectRepository } from '../git-utils.js';
+import { resolveTargetRepo } from '../config.js';
 
-export async function moveCommand(issue: string, status: string): Promise<void> {
+interface MoveOptions {
+    repo?: string;
+}
+
+export async function moveCommand(issue: string, status: string, options: MoveOptions): Promise<void> {
     const issueNumber = parseInt(issue, 10);
     if (isNaN(issueNumber)) {
         console.error(chalk.red('Error:'), 'Issue must be a number');
         process.exit(1);
     }
 
-    // Detect repository
-    const repo = await detectRepository();
+    // Resolve target repository (--repo flag > config.defaultRepo > detect from cwd)
+    const repo = await resolveTargetRepo(options.repo);
     if (!repo) {
-        console.error(chalk.red('Error:'), 'Not in a git repository with a GitHub remote');
+        if (options.repo) {
+            console.error(chalk.red('Error:'), `Invalid repo format: ${options.repo}`);
+            console.log(chalk.dim('Expected format: owner/name (e.g., bretwardjames/ghp-core)'));
+        } else {
+            console.error(chalk.red('Error:'), 'Could not determine target repository.');
+            console.log(chalk.dim('Use --repo owner/name or set defaultRepo in config'));
+        }
         process.exit(1);
     }
 
@@ -24,7 +34,17 @@ export async function moveCommand(issue: string, status: string): Promise<void> 
     }
 
     // Find the item
-    const item = await api.findItemByNumber(repo, issueNumber);
+    let item;
+    try {
+        item = await api.findItemByNumber(repo, issueNumber);
+    } catch (error) {
+        if (error instanceof Error && error.message.includes('Repository not found')) {
+            console.error(chalk.red('Error:'), `Repository not found: ${repo.owner}/${repo.name}`);
+            console.log(chalk.dim('Check that the repository exists and you have access to it.'));
+            process.exit(1);
+        }
+        throw error;
+    }
     if (!item) {
         console.error(chalk.red('Error:'), `Issue #${issueNumber} not found in any project`);
         process.exit(1);

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -1,17 +1,25 @@
 import chalk from 'chalk';
 import { api, type IssueDetails } from '../github-api.js';
-import { detectRepository } from '../git-utils.js';
+import { resolveTargetRepo } from '../config.js';
 import { parseBranchLink } from '@bretwardjames/ghp-core';
 import type { ProjectItem } from '../types.js';
 
 interface OpenOptions {
     browser?: boolean;
+    repo?: string;
 }
 
 export async function openCommand(issue: string, options: OpenOptions): Promise<void> {
-    const repo = await detectRepository();
+    // Resolve target repository (--repo flag > config.defaultRepo > detect from cwd)
+    const repo = await resolveTargetRepo(options.repo);
     if (!repo) {
-        console.error(chalk.red('Error:'), 'Not in a git repository with a GitHub remote');
+        if (options.repo) {
+            console.error(chalk.red('Error:'), `Invalid repo format: ${options.repo}`);
+            console.log(chalk.dim('Expected format: owner/name (e.g., bretwardjames/ghp-core)'));
+        } else {
+            console.error(chalk.red('Error:'), 'Could not determine target repository.');
+            console.log(chalk.dim('Use --repo owner/name or set defaultRepo in config'));
+        }
         process.exit(1);
     }
 

--- a/src/commands/switch.ts
+++ b/src/commands/switch.ts
@@ -1,19 +1,30 @@
 import chalk from 'chalk';
 import { api } from '../github-api.js';
-import { detectRepository, checkoutBranch, branchExists, getCurrentBranch } from '../git-utils.js';
+import { checkoutBranch, branchExists, getCurrentBranch } from '../git-utils.js';
 import { getBranchForIssue } from '../branch-linker.js';
+import { resolveTargetRepo } from '../config.js';
 
-export async function switchCommand(issue: string): Promise<void> {
+interface SwitchOptions {
+    repo?: string;
+}
+
+export async function switchCommand(issue: string, options: SwitchOptions): Promise<void> {
     const issueNumber = parseInt(issue, 10);
     if (isNaN(issueNumber)) {
         console.error(chalk.red('Error:'), 'Issue must be a number');
         process.exit(1);
     }
 
-    // Detect repository
-    const repo = await detectRepository();
+    // Resolve target repository (--repo flag > config.defaultRepo > detect from cwd)
+    const repo = await resolveTargetRepo(options.repo);
     if (!repo) {
-        console.error(chalk.red('Error:'), 'Not in a git repository with a GitHub remote');
+        if (options.repo) {
+            console.error(chalk.red('Error:'), `Invalid repo format: ${options.repo}`);
+            console.log(chalk.dim('Expected format: owner/name (e.g., bretwardjames/ghp-core)'));
+        } else {
+            console.error(chalk.red('Error:'), 'Could not determine target repository.');
+            console.log(chalk.dim('Use --repo owner/name or set defaultRepo in config'));
+        }
         process.exit(1);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,18 +89,21 @@ program
     .description('Start working on an issue - creates branch and updates status')
     .option('--no-branch', 'Skip branch creation')
     .option('--no-status', 'Skip status update')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(startCommand);
 
 program
     .command('done <issue>')
     .alias('d')
     .description('Mark an issue as done')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(doneCommand);
 
 program
     .command('move <issue> <status>')
     .alias('m')
     .description('Move an issue to a different status')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(moveCommand);
 
 // Branch commands
@@ -108,12 +111,14 @@ program
     .command('switch <issue>')
     .alias('sw')
     .description('Switch to the branch linked to an issue')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(switchCommand);
 
 program
     .command('link-branch <issue> [branch]')
     .alias('lb')
     .description('Link a branch to an issue (defaults to current branch)')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(linkBranchCommand);
 
 program
@@ -135,6 +140,7 @@ program
     .command('assign <issue> [users...]')
     .description('Assign users to an issue (empty to assign self)')
     .option('--remove', 'Remove assignment instead of adding')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(assignCommand);
 
 // Issue creation
@@ -148,6 +154,7 @@ program
     .option('-e, --edit', 'Open $EDITOR to write issue body')
     .option('-t, --template <name>', 'Use an issue template from .github/ISSUE_TEMPLATE/')
     .option('--list-templates', 'List available issue templates')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(addIssueCommand);
 
 // Field management
@@ -155,6 +162,7 @@ program
     .command('set-field <issue> <field> <value>')
     .alias('sf')
     .description('Set a field value on an issue')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(setFieldCommand);
 
 // Filtering/slicing
@@ -172,6 +180,7 @@ program
     .alias('o')
     .description('View issue details')
     .option('-b, --browser', 'Open in browser instead of terminal')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(openCommand);
 
 program
@@ -179,12 +188,14 @@ program
     .alias('c')
     .description('Add a comment to an issue')
     .option('-m, --message <text>', 'Comment text (opens editor if not provided)')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(commentCommand);
 
 program
     .command('edit <issue>')
     .alias('e')
     .description('Edit an issue description in $EDITOR')
+    .option('-r, --repo <owner/name>', 'Target repository (overrides config and auto-detect)')
     .action(editCommand);
 
 // Active label sync


### PR DESCRIPTION
## Summary
- Add `--repo owner/name` flag to all issue commands for targeting different repositories
- Add `defaultRepo` config setting for multi-repo projects
- Add `resolveTargetRepo()` helper: --repo flag > config.defaultRepo > auto-detect from cwd
- Improve error messages with helpful hints for repo format

## Updated Commands
All issue-related commands now support `--repo`:
- `start`, `done`, `move`
- `switch`, `link-branch`
- `assign`, `add-issue`
- `set-field`, `open`, `comment`, `edit`

## Config
```bash
ghp config set defaultRepo owner/repo
```

## Test plan
- [ ] Test `ghp start 123 --repo owner/other-repo` targets specified repo
- [ ] Test `ghp config set defaultRepo owner/repo` works as fallback
- [ ] Test auto-detect still works when no --repo or defaultRepo set
- [ ] Test error messages show helpful hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)